### PR TITLE
extract __version__ to separate file

### DIFF
--- a/pyswrve/__init__.py
+++ b/pyswrve/__init__.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
+from __version__ import __version__
 
 from .export_api import SwrveExportApi as ExportApi
 from .userdb_api import SwrveUserdbApi as UserdbApi
 from .items_api import SwrveItemsApi as ItemsApi
-
-version_info = (0, 4, 0, 'dev')
-__version__ = '.'.join(map(str, version_info))

--- a/pyswrve/__version__.py
+++ b/pyswrve/__version__.py
@@ -1,0 +1,2 @@
+version_info = (0, 4, 0, 'dev')
+__version__ = '.'.join(map(str, version_info))

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,19 @@
 # -*- coding: utf-8 -*-
+import os
 
 from distutils.core import setup
 
-from pyswrve import __version__
+
+here = os.path.abspath(os.path.dirname(__file__))
+
+version_ns = {}
+
+with open(os.path.join(here, "pyswrve", "__version__.py")) as f:
+    exec(f.read(), version_ns)
 
 setup(
     name='pyswrve',
-    version=__version__,
+    version=version_ns['__version__'],
     license='MIT License',
     url='https://github.com/xxblx/pyswrve',
 


### PR DESCRIPTION
Fixes `ModuleNotFoundError: No module named 'requests'` on `pip install pyswrve` when `requests` package not installed.